### PR TITLE
refactor: convert interface to type in types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type ISODate = string;
 
-export interface Transaction {
+export type Transaction = {
   id: string;
   date: ISODate;
   amount: number;
@@ -10,20 +10,20 @@ export interface Transaction {
   title: string;
   isTransfer: boolean;
   isManualEntry: boolean;
-}
+};
 
-export interface CategoryRef {
+export type CategoryRef = {
   largeId: string;
   largeName: string;
   middleId: string;
   middleName: string;
-}
+};
 
-export interface CategoryMeta {
+export type CategoryMeta = {
   large: Array<{ id: string; name: string }>;
   middle: Array<{ id: string; name: string; largeId: string }>;
   updatedAt: ISODate;
-}
+};
 
 export type ExitCode =
   | 0


### PR DESCRIPTION
## Summary

`src/types.ts` の `interface` 3つを `type` に変換。クラス継承・`implements` が発生しない場合は `type` を使う規約に準拠。

- `interface Transaction` → `type Transaction`
- `interface CategoryRef` → `type CategoryRef`
- `interface CategoryMeta` → `type CategoryMeta`

closes #19

## Test plan

- [x] `bun run typecheck` — エラーなし