### PR TITLE
refactor: convert all remaining interface to type

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,16 +1,16 @@
 import { chromium, type Browser, type BrowserContext } from "playwright";
 import { loadSession } from "./session.ts";
 
-export interface BrowserHandle {
+export type BrowserHandle = {
   browser: Browser;
   context: BrowserContext;
   close(): Promise<void>;
-}
+};
 
-export interface LaunchOptions {
+export type LaunchOptions = {
   headed?: boolean;
   requireSession?: boolean;
-}
+};
 
 // headless chromium の素の UA だと ME 側で弾かれるので固定値で偽装する
 const UA =

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,11 +3,11 @@ import { fetchTransactions } from "../scraper/transactions.ts";
 import { log } from "../log.ts";
 import { EXIT } from "../types.ts";
 
-export interface ListArgs {
+export type ListArgs = {
   since?: string;
   until?: string;
   format: "json" | "ndjson" | "csv";
-}
+};
 
 export async function runList(args: ListArgs): Promise<number> {
   const handle = await launch({ requireSession: true });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -7,12 +7,12 @@ import { log } from "../log.ts";
 import { EXIT } from "../types.ts";
 import type { CategoryMeta } from "../types.ts";
 
-export interface UpdateArgs {
+export type UpdateArgs = {
   txId: string;
   memo?: string;
   category?: string;
   dryRun: boolean;
-}
+};
 
 async function loadMeta(): Promise<CategoryMeta> {
   try {

--- a/src/scraper/transactions.ts
+++ b/src/scraper/transactions.ts
@@ -1,10 +1,10 @@
 import type { Page } from "playwright";
 import type { Transaction } from "../types.ts";
 
-export interface ListOptions {
+export type ListOptions = {
   since?: string;
   until?: string;
-}
+};
 
 function monthCursor(since: Date, until: Date): Array<{ from: string }> {
   const out: Array<{ from: string }> = [];

--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -1,11 +1,11 @@
 import type { Page } from "playwright";
 import type { CategoryMeta } from "../types.ts";
 
-export interface UpdatePayload {
+export type UpdatePayload = {
   memo?: string;
   largeCategoryId?: string;
   middleCategoryId?: string;
-}
+};
 
 export function resolveCategoryIds(
   meta: CategoryMeta,


### PR DESCRIPTION
## Summary

`types.ts` 以外に残っていた `interface` 6件を全て `type` に変換。

- `src/browser.ts`: `BrowserHandle`, `LaunchOptions`
- `src/commands/update.ts`: `UpdateArgs`
- `src/commands/list.ts`: `ListArgs`
- `src/scraper/update.ts`: `UpdatePayload`
- `src/scraper/transactions.ts`: `ListOptions`

closes #21

## Test plan

- [x] `bun run typecheck` — エラーなし