### PR TITLE
style: add blank lines between logical sections across source files

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -12,6 +12,7 @@ export type ListArgs = {
 export async function runList(args: ListArgs): Promise<number> {
   const handle = await launch({ requireSession: true });
   const page = await handle.context.newPage();
+
   try {
     const txs = await fetchTransactions(page, { since: args.since, until: args.until });
     if (args.format === "ndjson") {

--- a/src/commands/sync-meta.ts
+++ b/src/commands/sync-meta.ts
@@ -11,8 +11,10 @@ export async function runSyncMeta(): Promise<number> {
   const page = await handle.context.newPage();
   try {
     const meta = await fetchCategoryMeta(page);
+
     await mkdir(dirname(META_FILE), { recursive: true, mode: 0o700 });
     await writeFile(META_FILE, JSON.stringify(meta, null, 2), { mode: 0o600 });
+
     log.info(`saved ${meta.large.length} large / ${meta.middle.length} middle categories to ${META_FILE}`);
     return EXIT.OK;
   } catch (e) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -38,6 +38,7 @@ export async function runUpdate(args: UpdateArgs): Promise<number> {
   }
 
   const plan = { txId: args.txId, payload };
+
   if (args.dryRun) {
     process.stdout.write(JSON.stringify({ dryRun: true, ...plan }, null, 2) + "\n");
     return EXIT.OK;

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,9 +2,11 @@ export const log = {
   info(msg: string): void {
     process.stderr.write(`[info] ${msg}\n`);
   },
+
   warn(msg: string): void {
     process.stderr.write(`[warn] ${msg}\n`);
   },
+
   error(msg: string): void {
     process.stderr.write(`[error] ${msg}\n`);
   },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -9,4 +9,5 @@ export const STATE_DIR = join(xdgStateHome, "mfme");
 
 export const SESSION_FILE = join(CONFIG_DIR, "session.json");
 export const META_FILE = join(CONFIG_DIR, "meta.json");
+
 export const LOG_FILE = join(STATE_DIR, "mfme.log");

--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -14,19 +14,23 @@ export function resolveCategoryIds(
   const parts = spec.split("/").map((s) => s.trim());
   const largeName = parts[0];
   const middleName = parts[1];
+
   if (!largeName || !middleName) {
     throw new Error(`category must be "大項目/中項目" (got: ${spec})`);
   }
+
   const large = meta.large.find((l) => l.name === largeName);
   if (!large || !large.id) {
     throw new Error(`unknown large category: ${largeName} (未観測の可能性あり。該当カテゴリの取引を1件でも含む月で sync-meta を再実行してください)`);
   }
+
   const middle = meta.middle.find(
     (m) => m.name === middleName && m.largeId === large.id,
   );
   if (!middle || !middle.id) {
     throw new Error(`unknown middle category: ${middleName} under ${largeName} (未観測の可能性あり)`);
   }
+
   return { largeCategoryId: large.id, middleCategoryId: middle.id };
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,7 @@ export async function loadSession(): Promise<string | null> {
   } catch {
     return null;
   }
+
   await readFile(SESSION_FILE, "utf8");
   return SESSION_FILE;
 }


### PR DESCRIPTION
## Summary

意図（ロジックのまとまり）ごとに空行を挿入し、可読性を向上。

| ファイル | 変更箇所 |
|---|---|
| `src/log.ts` | メソッド間 |
| `src/paths.ts` | dir 定数と file 定数の間 |
| `src/session.ts` | `loadSession` の try/catch 後 |
| `src/commands/list.ts` | ハンドル生成と try の間 |
| `src/commands/sync-meta.ts` | fetch / write / log+return の間 |
| `src/commands/update.ts` | payload 構築と plan/dryRun の間 |
| `src/scraper/update.ts` | `resolveCategoryIds` の各フェーズ間 |

closes #23

## Test plan

- [x] `bun run typecheck` — エラーなし