### PR TITLE
Add oxlint and oxfmt as linter/formatter

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "semi": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "ignorePatterns": ["*.md", "bun.lock", "**/node_modules/", "**/tmp/"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,89 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "oxfmt": "^0.47.0",
+        "oxlint": "^1.62.0",
         "typescript": "^5.6.0",
       },
     },
   },
   "packages": {
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.47.0", "", { "os": "android", "cpu": "arm" }, "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.47.0", "", { "os": "android", "cpu": "arm64" }, "sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.47.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.47.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.47.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.47.0", "", { "os": "linux", "cpu": "arm" }, "sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.47.0", "", { "os": "linux", "cpu": "arm" }, "sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.47.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.47.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.47.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.47.0", "", { "os": "linux", "cpu": "none" }, "sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.47.0", "", { "os": "linux", "cpu": "none" }, "sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.47.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.47.0", "", { "os": "linux", "cpu": "x64" }, "sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.47.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.47.0", "", { "os": "none", "cpu": "arm64" }, "sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.47.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.47.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.47.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A=="],
+
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -25,9 +103,15 @@
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
+
+    "oxlint": ["oxlint@1.62.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.62.0", "@oxlint/binding-android-arm64": "1.62.0", "@oxlint/binding-darwin-arm64": "1.62.0", "@oxlint/binding-darwin-x64": "1.62.0", "@oxlint/binding-freebsd-x64": "1.62.0", "@oxlint/binding-linux-arm-gnueabihf": "1.62.0", "@oxlint/binding-linux-arm-musleabihf": "1.62.0", "@oxlint/binding-linux-arm64-gnu": "1.62.0", "@oxlint/binding-linux-arm64-musl": "1.62.0", "@oxlint/binding-linux-ppc64-gnu": "1.62.0", "@oxlint/binding-linux-riscv64-gnu": "1.62.0", "@oxlint/binding-linux-riscv64-musl": "1.62.0", "@oxlint/binding-linux-s390x-gnu": "1.62.0", "@oxlint/binding-linux-x64-gnu": "1.62.0", "@oxlint/binding-linux-x64-musl": "1.62.0", "@oxlint/binding-openharmony-arm64": "1.62.0", "@oxlint/binding-win32-arm64-msvc": "1.62.0", "@oxlint/binding-win32-ia32-msvc": "1.62.0", "@oxlint/binding-win32-x64-msvc": "1.62.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ=="],
+
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
   "name": "mfme-cli",
   "version": "0.1.0",
-  "description": "Unofficial CLI for Moneyforward ME (UI automation via Playwright)",
   "private": false,
-  "type": "module",
+  "description": "Unofficial CLI for Moneyforward ME (UI automation via Playwright)",
   "bin": {
     "mfme": "./src/cli.ts"
   },
+  "type": "module",
   "scripts": {
     "start": "bun run src/cli.ts",
     "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
     "install-browsers": "bun x playwright install chromium"
   },
   "dependencies": {
@@ -18,6 +21,8 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "oxfmt": "^0.47.0",
+    "oxlint": "^1.62.0",
     "typescript": "^5.6.0"
   },
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,10 +7,7 @@ import { runSyncMeta } from "../src/commands/sync-meta.ts";
 
 const program = new Command();
 
-program
-  .name("mfme")
-  .description("Unofficial Moneyforward ME CLI (UI automation)")
-  .version("0.1.0");
+program.name("mfme").description("Unofficial Moneyforward ME CLI (UI automation)").version("0.1.0");
 
 program
   .command("login")

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -13,10 +13,13 @@ export async function runLogin(): Promise<number> {
   await page.goto(URL_SIGN_IN);
 
   try {
-    await page.waitForURL((u) => {
-      const url = new URL(u.toString());
-      return url.host === HOST_ME && !url.pathname.startsWith("/sign_in");
-    }, { timeout: 10 * 60_000 });
+    await page.waitForURL(
+      (u) => {
+        const url = new URL(u.toString());
+        return url.host === HOST_ME && !url.pathname.startsWith("/sign_in");
+      },
+      { timeout: 10 * 60_000 },
+    );
   } catch {
     log.error("ログイン待機がタイムアウトしました");
     await browser.close();

--- a/src/commands/sync-meta.ts
+++ b/src/commands/sync-meta.ts
@@ -15,7 +15,9 @@ export async function runSyncMeta(): Promise<number> {
     await mkdir(dirname(META_FILE), { recursive: true, mode: 0o700 });
     await writeFile(META_FILE, JSON.stringify(meta, null, 2), { mode: 0o600 });
 
-    log.info(`saved ${meta.large.length} large / ${meta.middle.length} middle categories to ${META_FILE}`);
+    log.info(
+      `saved ${meta.large.length} large / ${meta.middle.length} middle categories to ${META_FILE}`,
+    );
     return EXIT.OK;
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));

--- a/src/scraper/categories.ts
+++ b/src/scraper/categories.ts
@@ -9,17 +9,17 @@ export async function fetchCategoryMeta(page: Page): Promise<CategoryMeta> {
   // 全大項目 (l_c_name) と各配下の中項目 (sub_menu > m_c_name) が一括描画される
   await page.click("tr.transaction_list .v_l_ctg");
   // サーバーからの async 描画待ち
-  await page.waitForFunction(
-    () => document.querySelectorAll("a.l_c_name").length > 0,
-    undefined,
-    { timeout: 10_000 },
-  );
+  await page.waitForFunction(() => document.querySelectorAll("a.l_c_name").length > 0, undefined, {
+    timeout: 10_000,
+  });
 
   const data = await page.evaluate(() => {
-    const large = Array.from(document.querySelectorAll<HTMLAnchorElement>("a.l_c_name")).map((a) => ({
-      id: a.getAttribute("id") ?? "",
-      name: (a.textContent ?? "").trim(),
-    }));
+    const large = Array.from(document.querySelectorAll<HTMLAnchorElement>("a.l_c_name")).map(
+      (a) => ({
+        id: a.getAttribute("id") ?? "",
+        name: (a.textContent ?? "").trim(),
+      }),
+    );
 
     const middle: Array<{ id: string; name: string; largeId: string }> = [];
     document.querySelectorAll<HTMLUListElement>("ul.sub_menu").forEach((ul) => {

--- a/src/scraper/transactions.ts
+++ b/src/scraper/transactions.ts
@@ -19,7 +19,9 @@ function monthCursor(since: Date, until: Date): Array<{ from: string }> {
 export async function fetchTransactions(page: Page, opts: ListOptions): Promise<Transaction[]> {
   const now = new Date();
   const until = opts.until ? new Date(opts.until) : now;
-  const since = opts.since ? new Date(opts.since) : new Date(until.getFullYear(), until.getMonth(), 1);
+  const since = opts.since
+    ? new Date(opts.since)
+    : new Date(until.getFullYear(), until.getMonth(), 1);
   const months = monthCursor(since, until);
 
   // 初回に /cf を開いて CSRF token / jQuery / list_body を確立
@@ -39,8 +41,7 @@ export async function fetchTransactions(page: Page, opts: ListOptions): Promise<
 // それを eval することで `.list_body` に対象月の行が差し込まれる。
 async function fetchMonthIntoDom(page: Page, from: string): Promise<void> {
   const ok = await page.evaluate(async (fromDate) => {
-    const token =
-      document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? "";
+    const token = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? "";
     const body = new URLSearchParams({ from: fromDate, service_id: "", account_id_hash: "" });
     const res = await fetch("/cf/fetch", {
       method: "POST",
@@ -72,29 +73,29 @@ async function parseRows(page: Page): Promise<Transaction[]> {
       const id = idAttr.replace(/^js-transaction-/, "");
       const hiddenId = q<HTMLInputElement>('input[name="user_asset_act[id]"]')?.value ?? id;
 
-      const dateAttr = q('td.date')?.getAttribute("data-table-sortable-value") ?? "";
+      const dateAttr = q("td.date")?.getAttribute("data-table-sortable-value") ?? "";
       const dateYmd = dateAttr.split("-")[0] ?? "";
       const isoDate = dateYmd.replaceAll("/", "-");
 
-      const title = (q('td.content span')?.textContent ?? "").trim();
-      const amountRaw = (q('td.amount .offset')?.textContent ?? "0").replace(/[^0-9-]/g, "");
-      const account = (q('td.note')?.textContent ?? "").trim();
-      const largeName = (q('.v_l_ctg')?.textContent ?? "").trim().replace(/\s+/g, " ");
-      const middleName = (q('.v_m_ctg')?.textContent ?? "").trim().replace(/\s+/g, " ");
-      const largeId = q<HTMLInputElement>('input.h_l_ctg')?.value ?? "";
-      const middleId = q<HTMLInputElement>('input.h_m_ctg')?.value ?? "";
-      const memo = (q('td.memo .noform span')?.textContent ?? "").trim();
-      const isTransfer = tr.classList.contains("transfer") || !!q('.icon-exchange.active');
-      const isManualEntry = !!q('input[name="user_asset_act[table_name]"][value="user_manual_cache_act"]');
+      const title = (q("td.content span")?.textContent ?? "").trim();
+      const amountRaw = (q("td.amount .offset")?.textContent ?? "0").replace(/[^0-9-]/g, "");
+      const account = (q("td.note")?.textContent ?? "").trim();
+      const largeName = (q(".v_l_ctg")?.textContent ?? "").trim().replace(/\s+/g, " ");
+      const middleName = (q(".v_m_ctg")?.textContent ?? "").trim().replace(/\s+/g, " ");
+      const largeId = q<HTMLInputElement>("input.h_l_ctg")?.value ?? "";
+      const middleId = q<HTMLInputElement>("input.h_m_ctg")?.value ?? "";
+      const memo = (q("td.memo .noform span")?.textContent ?? "").trim();
+      const isTransfer = tr.classList.contains("transfer") || !!q(".icon-exchange.active");
+      const isManualEntry = !!q(
+        'input[name="user_asset_act[table_name]"][value="user_manual_cache_act"]',
+      );
 
       return {
         id: hiddenId || id,
         date: isoDate,
         amount: Number(amountRaw) || 0,
         account,
-        category: largeName || middleName
-          ? { largeId, largeName, middleId, middleName }
-          : null,
+        category: largeName || middleName ? { largeId, largeName, middleId, middleName } : null,
         memo: memo || null,
         title,
         isTransfer,

--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -21,14 +21,16 @@ export function resolveCategoryIds(
 
   const large = meta.large.find((l) => l.name === largeName);
   if (!large || !large.id) {
-    throw new Error(`unknown large category: ${largeName} (未観測の可能性あり。該当カテゴリの取引を1件でも含む月で sync-meta を再実行してください)`);
+    throw new Error(
+      `unknown large category: ${largeName} (未観測の可能性あり。該当カテゴリの取引を1件でも含む月で sync-meta を再実行してください)`,
+    );
   }
 
-  const middle = meta.middle.find(
-    (m) => m.name === middleName && m.largeId === large.id,
-  );
+  const middle = meta.middle.find((m) => m.name === middleName && m.largeId === large.id);
   if (!middle || !middle.id) {
-    throw new Error(`unknown middle category: ${middleName} under ${largeName} (未観測の可能性あり)`);
+    throw new Error(
+      `unknown middle category: ${middleName} under ${largeName} (未観測の可能性あり)`,
+    );
   }
 
   return { largeCategoryId: large.id, middleCategoryId: middle.id };
@@ -49,8 +51,10 @@ export async function updateTransaction(
       form.set("user_asset_act[id]", txId);
       form.set("user_asset_act[table_name]", "user_asset_act");
       if (payload.memo !== undefined) form.set("user_asset_act[memo]", payload.memo);
-      if (payload.largeCategoryId) form.set("user_asset_act[large_category_id]", payload.largeCategoryId);
-      if (payload.middleCategoryId) form.set("user_asset_act[middle_category_id]", payload.middleCategoryId);
+      if (payload.largeCategoryId)
+        form.set("user_asset_act[large_category_id]", payload.largeCategoryId);
+      if (payload.middleCategoryId)
+        form.set("user_asset_act[middle_category_id]", payload.middleCategoryId);
 
       const res = await fetch("/cf/update", {
         method: "POST",

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,12 +25,7 @@ export type CategoryMeta = {
   updatedAt: ISODate;
 };
 
-export type ExitCode =
-  | 0
-  | 1
-  | 2
-  | 3
-  | 4;
+export type ExitCode = 0 | 1 | 2 | 3 | 4;
 
 export const EXIT = {
   OK: 0,


### PR DESCRIPTION
Closes #25

## Summary

- `oxlint` と `oxfmt` を devDependencies に追加
- `package.json` scripts に `lint` / `format` / `format:check` を追加
- `.oxfmtrc.json` を作成（printWidth: 100、ダブルクォート・セミコロンあり）
- 既存ソースに初回フォーマットを適用（挙動変更なし）

## Test plan

- [ ] `bun run lint` → `Found 0 warnings and 0 errors.`
- [ ] `bun run format:check` → `All matched files use the correct format.`
- [ ] `bun run typecheck` → エラーなし