### PR TITLE
fix: map exit codes by error type in list/update commands

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,5 @@
 import { launch } from "../browser.ts";
+import { AppError } from "../errors.ts";
 import { fetchTransactions } from "../scraper/transactions.ts";
 import { log } from "../log.ts";
 import { EXIT } from "../types.ts";
@@ -32,7 +33,7 @@ export async function runList(args: ListArgs): Promise<number> {
     return EXIT.OK;
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));
-    return EXIT.ELEMENT_NOT_FOUND;
+    return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
   } finally {
     await handle.close();
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { launch } from "../browser.ts";
+import { AppError } from "../errors.ts";
 import { META_FILE } from "../paths.ts";
 import { URL_CF } from "../scraper/urls.ts";
 import { resolveCategoryIds, updateTransaction } from "../scraper/update.ts";
@@ -18,7 +19,10 @@ async function loadMeta(): Promise<CategoryMeta> {
   try {
     return JSON.parse(await readFile(META_FILE, "utf8")) as CategoryMeta;
   } catch {
-    throw new Error(`meta not found. run \`mfme sync-meta\` first (${META_FILE})`);
+    throw new AppError(
+      `meta not found. run \`mfme sync-meta\` first (${META_FILE})`,
+      EXIT.INVALID_INPUT,
+    );
   }
 }
 
@@ -53,7 +57,7 @@ export async function runUpdate(args: UpdateArgs): Promise<number> {
     return EXIT.OK;
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));
-    return EXIT.UNKNOWN;
+    return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
   } finally {
     await handle.close();
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,11 @@
+import type { ExitCode } from "./types.ts";
+
+export class AppError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: ExitCode,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}

--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -1,5 +1,7 @@
 import type { Page } from "playwright";
+import { AppError } from "../errors.ts";
 import type { CategoryMeta } from "../types.ts";
+import { EXIT } from "../types.ts";
 
 export type UpdatePayload = {
   memo?: string;
@@ -16,20 +18,22 @@ export function resolveCategoryIds(
   const middleName = parts[1];
 
   if (!largeName || !middleName) {
-    throw new Error(`category must be "大項目/中項目" (got: ${spec})`);
+    throw new AppError(`category must be "大項目/中項目" (got: ${spec})`, EXIT.INVALID_INPUT);
   }
 
   const large = meta.large.find((l) => l.name === largeName);
   if (!large || !large.id) {
-    throw new Error(
+    throw new AppError(
       `unknown large category: ${largeName} (未観測の可能性あり。該当カテゴリの取引を1件でも含む月で sync-meta を再実行してください)`,
+      EXIT.INVALID_INPUT,
     );
   }
 
   const middle = meta.middle.find((m) => m.name === middleName && m.largeId === large.id);
   if (!middle || !middle.id) {
-    throw new Error(
+    throw new AppError(
       `unknown middle category: ${middleName} under ${largeName} (未観測の可能性あり)`,
+      EXIT.INVALID_INPUT,
     );
   }
 


### PR DESCRIPTION
Closes #2

## Summary

- `src/errors.ts` に `AppError` クラスを追加（`exitCode` フィールドを持つ）
- `resolveCategoryIds` / `loadMeta` が投げるエラーを `AppError(INVALID_INPUT=3)` に変更
- `list.ts` / `update.ts` の catch で `AppError` なら `exitCode` を、それ以外は `UNKNOWN(4)` を返すよう修正
- `list.ts` が全エラーを `ELEMENT_NOT_FOUND(2)` に丸めていた問題を解消

## Test plan

- [ ] `bun run typecheck` / `bun run lint` が通る
- [ ] `mfme update --category "存在しない/カテゴリ"` → exit 3
- [ ] `mfme update` でメタファイルなし → exit 3