### PR TITLE
chore: add CI workflow (bun install + typecheck + lint + format + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bun run format:check
+      - run: bun test


### PR DESCRIPTION
Closes #9

## Summary

`.github/workflows/ci.yml` を追加。PR・main push で以下を自動実行:

1. `bun install --frozen-lockfile`
2. `bun run typecheck` (tsgo)
3. `bun run lint` (oxlint)
4. `bun run format:check` (oxfmt)
5. `bun test`（#8 でテスト追加後に有効になる）

Playwright ブラウザのインストールは CI では行わない。

## Test plan

- [ ] PR 作成時に CI が起動すること