### PR TITLE
fix: remove unused readFile call in loadSession

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile, stat } from "node:fs/promises";
+import { mkdir, writeFile, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SESSION_FILE } from "./paths.ts";
 
@@ -14,7 +14,6 @@ export async function loadSession(): Promise<string | null> {
     return null;
   }
 
-  await readFile(SESSION_FILE, "utf8");
   return SESSION_FILE;
 }
 


### PR DESCRIPTION
Closes #1

## Summary

`loadSession` で `stat` による存在確認の後に `readFile` を呼んでいたが戻り値を捨てていた。無駄 I/O を除去し `readFile` と import を削除。

## Test plan

- [ ] `bun run typecheck` が通る
- [ ] `mfme list` / `mfme login` が正常に動作する