### PR TITLE
refactor: reuse launch() in login command

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,15 +1,14 @@
-import { chromium } from "playwright";
+import { launch } from "../browser.ts";
 import { saveSession } from "../session.ts";
 import { HOST_ME, URL_SIGN_IN } from "../scraper/urls.ts";
 import { log } from "../log.ts";
+import { EXIT } from "../types.ts";
 
 export async function runLogin(): Promise<number> {
-  const browser = await chromium.launch({ headless: false });
-  const context = await browser.newContext();
-  const page = await context.newPage();
+  const handle = await launch({ headed: true, requireSession: false });
+  const page = await handle.context.newPage();
 
   log.info("ブラウザでログインしてください (MFA 含む)。ME 側に戻ってきたら自動で保存します。");
-  // ME の /sign_in → SSO で id.moneyforward.com へ → 認証後に ME の認証済みページへ戻る
   await page.goto(URL_SIGN_IN);
 
   try {
@@ -22,13 +21,13 @@ export async function runLogin(): Promise<number> {
     );
   } catch {
     log.error("ログイン待機がタイムアウトしました");
-    await browser.close();
-    return 1;
+    await handle.close();
+    return EXIT.AUTH_FAILED;
   }
 
-  const storageState = await context.storageState();
+  const storageState = await handle.context.storageState();
   await saveSession(storageState);
   log.info(`セッションを保存しました (final URL: ${page.url()})`);
-  await browser.close();
-  return 0;
+  await handle.close();
+  return EXIT.OK;
 }


### PR DESCRIPTION
Closes #10

## Summary

`login.ts` が `chromium.launch` / `newContext` を直接呼んでいたのを `launch({ headed: true, requireSession: false })` に統一。

- UA 偽装が login 時にも適用されるようになった
- context 初期化ロジックが `browser.ts` 一箇所に集約された
- タイムアウト時の close も `handle.close()` に統一

## Test plan

- [ ] `bun run typecheck` が通る
- [ ] `mfme login` でブラウザが headed で起動する