### PR TITLE
fix: reject category spec with wrong number of slash-separated parts

### DIFF
--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -17,7 +17,7 @@ export function resolveCategoryIds(
   const largeName = parts[0];
   const middleName = parts[1];
 
-  if (!largeName || !middleName) {
+  if (parts.length !== 2 || !largeName || !middleName) {
     throw new AppError(`category must be "大項目/中項目" (got: ${spec})`, EXIT.INVALID_INPUT);
   }
 


### PR DESCRIPTION
Closes #3

## Summary

`resolveCategoryIds` の `spec.split("/")` で `parts.length !== 2` を明示チェックするよう修正。

- `大項目/中項目/余分` のような3要素以上の入力が silent に通っていた問題を解消
- `parts.length !== 2` の場合は既存の `AppError(INVALID_INPUT=3)` を投げる

## Test plan

- [ ] `mfme update <id> --category "A/B/C"` → exit 3 でエラーメッセージ
- [ ] `mfme update <id> --category "食費/外食"` → 正常動作