### PR TITLE
feat: detect session expiry and exit AUTH_FAILED(1) cleanly

### DIFF
--- a/src/commands/sync-meta.ts
+++ b/src/commands/sync-meta.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { launch } from "../browser.ts";
+import { AppError } from "../errors.ts";
 import { META_FILE } from "../paths.ts";
 import { fetchCategoryMeta } from "../scraper/categories.ts";
 import { log } from "../log.ts";
@@ -21,7 +22,7 @@ export async function runSyncMeta(): Promise<number> {
     return EXIT.OK;
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));
-    return EXIT.ELEMENT_NOT_FOUND;
+    return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
   } finally {
     await handle.close();
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { launch } from "../browser.ts";
 import { AppError } from "../errors.ts";
 import { META_FILE } from "../paths.ts";
+import { assertAuthenticated } from "../scraper/auth.ts";
 import { URL_CF } from "../scraper/urls.ts";
 import { resolveCategoryIds, updateTransaction } from "../scraper/update.ts";
 import { log } from "../log.ts";
@@ -52,6 +53,7 @@ export async function runUpdate(args: UpdateArgs): Promise<number> {
   const page = await handle.context.newPage();
   try {
     await page.goto(URL_CF, { waitUntil: "domcontentloaded" });
+    await assertAuthenticated(page);
     await updateTransaction(page, args.txId, payload);
     process.stdout.write(JSON.stringify({ ok: true, ...plan }, null, 2) + "\n");
     return EXIT.OK;

--- a/src/scraper/auth.ts
+++ b/src/scraper/auth.ts
@@ -1,0 +1,11 @@
+import type { Page } from "playwright";
+import { AppError } from "../errors.ts";
+import { EXIT } from "../types.ts";
+import { HOST_ME } from "./urls.ts";
+
+export async function assertAuthenticated(page: Page): Promise<void> {
+  const url = new URL(page.url());
+  if (url.host !== HOST_ME || url.pathname.startsWith("/sign_in")) {
+    throw new AppError("session expired. run `mfme login` again.", EXIT.AUTH_FAILED);
+  }
+}

--- a/src/scraper/categories.ts
+++ b/src/scraper/categories.ts
@@ -1,8 +1,10 @@
 import type { Page } from "playwright";
 import type { CategoryMeta } from "../types.ts";
+import { assertAuthenticated } from "./auth.ts";
 
 export async function fetchCategoryMeta(page: Page): Promise<CategoryMeta> {
   await page.goto("https://moneyforward.com/cf", { waitUntil: "domcontentloaded" });
+  await assertAuthenticated(page);
   await page.waitForSelector("tr.transaction_list .v_l_ctg", { timeout: 20_000 });
 
   // 既存の取引行の大項目ドロップダウンをクリックすると

--- a/src/scraper/transactions.ts
+++ b/src/scraper/transactions.ts
@@ -1,5 +1,6 @@
 import type { Page } from "playwright";
 import type { Transaction } from "../types.ts";
+import { assertAuthenticated } from "./auth.ts";
 
 export type ListOptions = {
   since?: string;
@@ -35,6 +36,7 @@ export async function fetchTransactions(page: Page, opts: ListOptions): Promise<
 
   // 初回に /cf を開いて CSRF token / jQuery / list_body を確立
   await page.goto("https://moneyforward.com/cf", { waitUntil: "domcontentloaded" });
+  await assertAuthenticated(page);
   await page.waitForSelector("tr.transaction_list", { timeout: 20_000 });
 
   const results: Transaction[] = [];


### PR DESCRIPTION
Closes #5

## Summary

- `src/scraper/auth.ts` に `assertAuthenticated(page)` を追加
- `/cf` goto 後に URL が `moneyforward.com` 以外 or `/sign_in` なら `AppError(AUTH_FAILED=1)` を throw
- `transactions.ts` / `categories.ts` / `commands/update.ts` の `page.goto(URL_CF)` 直後に呼び出し
- `sync-meta.ts` の catch を `AppError` ベースに修正（`ELEMENT_NOT_FOUND` 固定→種別で分岐）

## Test plan

- [ ] セッション切れ状態で `mfme list` → exit 1 + `session expired. run \`mfme login\` again.`
- [ ] セッション切れ状態で `mfme update` → exit 1
- [ ] セッション切れ状態で `mfme sync-meta` → exit 1