### PR TITLE
feat: verify /cf/update response body and fix AppError propagation

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -28,39 +28,41 @@ async function loadMeta(): Promise<CategoryMeta> {
 }
 
 export async function runUpdate(args: UpdateArgs): Promise<number> {
-  if (!args.memo && !args.category) {
-    log.error("--memo か --category のどちらかは必須です");
-    return EXIT.INVALID_INPUT;
-  }
-
-  const payload: { memo?: string; largeCategoryId?: string; middleCategoryId?: string } = {};
-  if (args.memo !== undefined) payload.memo = args.memo;
-  if (args.category) {
-    const meta = await loadMeta();
-    const { largeCategoryId, middleCategoryId } = resolveCategoryIds(meta, args.category);
-    payload.largeCategoryId = largeCategoryId;
-    payload.middleCategoryId = middleCategoryId;
-  }
-
-  const plan = { txId: args.txId, payload };
-
-  if (args.dryRun) {
-    process.stdout.write(JSON.stringify({ dryRun: true, ...plan }, null, 2) + "\n");
-    return EXIT.OK;
-  }
-
-  const handle = await launch({ requireSession: true });
-  const page = await handle.context.newPage();
   try {
-    await page.goto(URL_CF, { waitUntil: "domcontentloaded" });
-    await assertAuthenticated(page);
-    await updateTransaction(page, args.txId, payload);
-    process.stdout.write(JSON.stringify({ ok: true, ...plan }, null, 2) + "\n");
-    return EXIT.OK;
+    if (!args.memo && !args.category) {
+      log.error("--memo か --category のどちらかは必須です");
+      return EXIT.INVALID_INPUT;
+    }
+
+    const payload: { memo?: string; largeCategoryId?: string; middleCategoryId?: string } = {};
+    if (args.memo !== undefined) payload.memo = args.memo;
+    if (args.category) {
+      const meta = await loadMeta();
+      const { largeCategoryId, middleCategoryId } = resolveCategoryIds(meta, args.category);
+      payload.largeCategoryId = largeCategoryId;
+      payload.middleCategoryId = middleCategoryId;
+    }
+
+    const plan = { txId: args.txId, payload };
+
+    if (args.dryRun) {
+      process.stdout.write(JSON.stringify({ dryRun: true, ...plan }, null, 2) + "\n");
+      return EXIT.OK;
+    }
+
+    const handle = await launch({ requireSession: true });
+    const page = await handle.context.newPage();
+    try {
+      await page.goto(URL_CF, { waitUntil: "domcontentloaded" });
+      await assertAuthenticated(page);
+      await updateTransaction(page, args.txId, payload);
+      process.stdout.write(JSON.stringify({ ok: true, ...plan }, null, 2) + "\n");
+      return EXIT.OK;
+    } finally {
+      await handle.close();
+    }
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));
     return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
-  } finally {
-    await handle.close();
   }
 }

--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -72,13 +72,22 @@ export async function updateTransaction(
         credentials: "same-origin",
       });
       const text = await res.text();
-      return { ok: res.ok, status: res.status, bodySnippet: text.slice(0, 300) };
+      let bodyError: string | null = null;
+      try {
+        const json = JSON.parse(text) as Record<string, unknown>;
+        if (typeof json["error"] === "string" && json["error"]) bodyError = json["error"];
+      } catch {
+        // non-JSON body — ignore
+      }
+      return { ok: res.ok, status: res.status, bodyError, bodySnippet: text.slice(0, 300) };
     },
     { txId, payload },
   );
-  if (!result.ok) {
+  if (!result.ok || result.bodyError) {
     throw new Error(
-      `update failed: HTTP ${result.status}${result.bodySnippet ? ` body=${result.bodySnippet}` : ""}`,
+      result.bodyError
+        ? `update rejected: ${result.bodyError}`
+        : `update failed: HTTP ${result.status}${result.bodySnippet ? ` body=${result.bodySnippet}` : ""}`,
     );
   }
 }


### PR DESCRIPTION
Closes #6

## Summary

- `/cf/update` レスポンス body を JSON parse し、`error` フィールドがあれば失敗扱いに変更
  - 実測: `{"status": 404, "error": "Not Found"}` → `update rejected: Not Found`
- `runUpdate` 全体を try/catch で囲み、payload 組み立て中（`loadMeta` / `resolveCategoryIds`）の `AppError` が未捕捉になっていた問題を修正
  - 修正前: `AppError` がスタックトレースで出て exit 1
  - 修正後: `[error] ...` + 正しい exit code（3 など）

## Test plan

- [x] `mfme update <invalid_id> --memo test` → `update rejected: Not Found` / exit 4
- [x] `mfme update <id> --category "存在しない/カテゴリ"` → exit 3（スタックトレースなし）