### PR TITLE
security: validate /cf/fetch content-type and body before eval

### DIFF
--- a/src/scraper/transactions.ts
+++ b/src/scraper/transactions.ts
@@ -65,14 +65,19 @@ async function fetchMonthIntoDom(page: Page, from: string): Promise<void> {
       },
       body: body.toString(),
     });
-    if (!res.ok) return { ok: false, status: res.status };
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const contentType = res.headers.get("content-type") ?? "";
     const text = await res.text();
-    // eslint-disable-next-line no-eval
+    if (!contentType.includes("javascript") || !text.includes("list_body")) {
+      return { ok: false, error: `unexpected response (content-type: ${contentType})` };
+    }
+    // ME の /cf/fetch は jQuery で .list_body を書き換える JS を返す。
+    // HTML パース不要で DOM 更新できる唯一の手段として eval を使用。
     (0, eval)(text);
-    return { ok: true, status: res.status };
+    return { ok: true, error: null };
   }, from);
   if (!ok.ok) {
-    throw new Error(`/cf/fetch failed: HTTP ${ok.status} (from=${from})`);
+    throw new Error(`/cf/fetch failed: ${ok.error} (from=${from})`);
   }
 }
 


### PR DESCRIPTION
Closes #7

## Summary

`/cf/fetch` のレスポンスを `eval` する前に以下を検証するよう変更:

1. `Content-Type` ヘッダーが `javascript` を含むこと
2. レスポンス body に `list_body` が含まれること

いずれも満たさない場合は `unexpected response (content-type: ...)` エラーで即失敗。セッション切れ時に HTML が返った場合も eval 前に検知できる。

また、eval が必要な理由（ME の /cf/fetch が jQuery で .list_body を書き換える JS を返すため）をコメントで明記。

## Test plan

- [x] `mfme list --since 2026-05-01` → 正常動作（3件取得）