### PR TITLE
test: add unit tests for pure helpers

### DIFF
--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { toCsvRow } from "./list.ts";
+import type { Transaction } from "../types.ts";
+
+const baseTx: Transaction = {
+  id: "123",
+  date: "2026-01-15",
+  amount: 1000,
+  account: "三井住友銀行",
+  category: { largeId: "L1", largeName: "食費", middleId: "M1", middleName: "外食" },
+  memo: null,
+  title: "スターバックス",
+  isTransfer: false,
+  isManualEntry: false,
+};
+
+describe("toCsvRow", () => {
+  test("通常行", () => {
+    expect(toCsvRow(baseTx)).toBe(
+      `"123","2026-01-15","1000","三井住友銀行","食費/外食","","スターバックス"`,
+    );
+  });
+
+  test('memo に " が含まれる場合はエスケープ', () => {
+    const tx = { ...baseTx, memo: 'メモ"テスト"' };
+    expect(toCsvRow(tx)).toContain('"メモ""テスト"""');
+  });
+
+  test("カテゴリなし", () => {
+    const tx = { ...baseTx, category: null };
+    expect(toCsvRow(tx)).toContain('""');
+  });
+
+  test("memo なし → 空文字", () => {
+    const tx = { ...baseTx, memo: null };
+    const row = toCsvRow(tx);
+    const cols = row.split(",");
+    expect(cols[5]).toBe('""');
+  });
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -10,6 +10,13 @@ export type ListArgs = {
   format: "json" | "ndjson" | "csv";
 };
 
+export function toCsvRow(tx: import("../types.ts").Transaction): string {
+  const cat = tx.category ? `${tx.category.largeName}/${tx.category.middleName}` : "";
+  return [tx.id, tx.date, tx.amount, tx.account, cat, tx.memo ?? "", tx.title]
+    .map((v) => `"${String(v).replaceAll('"', '""')}"`)
+    .join(",");
+}
+
 export async function runList(args: ListArgs): Promise<number> {
   const handle = await launch({ requireSession: true });
   const page = await handle.context.newPage();
@@ -21,11 +28,7 @@ export async function runList(args: ListArgs): Promise<number> {
     } else if (args.format === "csv") {
       process.stdout.write("id,date,amount,account,category,memo,title\n");
       for (const tx of txs) {
-        const cat = tx.category ? `${tx.category.largeName}/${tx.category.middleName}` : "";
-        const row = [tx.id, tx.date, tx.amount, tx.account, cat, tx.memo ?? "", tx.title]
-          .map((v) => `"${String(v).replaceAll('"', '""')}"`)
-          .join(",");
-        process.stdout.write(row + "\n");
+        process.stdout.write(toCsvRow(tx) + "\n");
       }
     } else {
       process.stdout.write(JSON.stringify(txs, null, 2) + "\n");

--- a/src/scraper/transactions.test.ts
+++ b/src/scraper/transactions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { monthCursor, filterByDate } from "./transactions.ts";
+import type { Transaction } from "../types.ts";
+
+const baseTx: Omit<Transaction, "date"> = {
+  id: "1",
+  amount: 100,
+  account: "bank",
+  category: null,
+  memo: null,
+  title: "test",
+  isTransfer: false,
+  isManualEntry: false,
+};
+
+function tx(date: string): Transaction {
+  return { ...baseTx, date };
+}
+
+describe("monthCursor", () => {
+  test("同月", () => {
+    expect(monthCursor("2026-01-01", "2026-01-31")).toEqual([{ from: "2026/1/1" }]);
+  });
+
+  test("複数月", () => {
+    expect(monthCursor("2026-01-01", "2026-03-31")).toEqual([
+      { from: "2026/1/1" },
+      { from: "2026/2/1" },
+      { from: "2026/3/1" },
+    ]);
+  });
+
+  test("年跨ぎ", () => {
+    expect(monthCursor("2025-11-01", "2026-02-01")).toEqual([
+      { from: "2025/11/1" },
+      { from: "2025/12/1" },
+      { from: "2026/1/1" },
+      { from: "2026/2/1" },
+    ]);
+  });
+});
+
+describe("filterByDate", () => {
+  const txs = [tx("2026-01-01"), tx("2026-01-15"), tx("2026-01-31"), tx("2026-02-01")];
+
+  test("境界日を含む (inclusive)", () => {
+    const result = filterByDate(txs, "2026-01-01", "2026-01-31");
+    expect(result.map((t) => t.date)).toEqual(["2026-01-01", "2026-01-15", "2026-01-31"]);
+  });
+
+  test("since より前を除外", () => {
+    const result = filterByDate(txs, "2026-01-15", "2026-02-01");
+    expect(result.map((t) => t.date)).toEqual(["2026-01-15", "2026-01-31", "2026-02-01"]);
+  });
+
+  test("空リスト", () => {
+    expect(filterByDate([], "2026-01-01", "2026-01-31")).toEqual([]);
+  });
+});

--- a/src/scraper/transactions.ts
+++ b/src/scraper/transactions.ts
@@ -12,7 +12,7 @@ function todayYmd(): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-function monthCursor(since: string, until: string): Array<{ from: string }> {
+export function monthCursor(since: string, until: string): Array<{ from: string }> {
   const [sy, sm] = since.split("-").map(Number) as [number, number];
   const [uy, um] = until.split("-").map(Number) as [number, number];
   const out: Array<{ from: string }> = [];
@@ -121,6 +121,6 @@ async function parseRows(page: Page): Promise<Transaction[]> {
   );
 }
 
-function filterByDate(txs: Transaction[], since: string, until: string): Transaction[] {
+export function filterByDate(txs: Transaction[], since: string, until: string): Transaction[] {
   return txs.filter((tx) => tx.date >= since && tx.date <= until);
 }

--- a/src/scraper/update.test.ts
+++ b/src/scraper/update.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCategoryIds } from "./update.ts";
+import type { CategoryMeta } from "../types.ts";
+
+const meta: CategoryMeta = {
+  large: [
+    { id: "L1", name: "食費" },
+    { id: "L2", name: "交通費" },
+  ],
+  middle: [
+    { id: "M1", name: "外食", largeId: "L1" },
+    { id: "M2", name: "コンビニ", largeId: "L1" },
+    { id: "M3", name: "電車", largeId: "L2" },
+    { id: "M4", name: "外食", largeId: "L2" },
+  ],
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("resolveCategoryIds", () => {
+  test("正常: 大項目/中項目", () => {
+    expect(resolveCategoryIds(meta, "食費/外食")).toEqual({
+      largeCategoryId: "L1",
+      middleCategoryId: "M1",
+    });
+  });
+
+  test("正常: 同名中項目でも別大項目なら正しく解決", () => {
+    expect(resolveCategoryIds(meta, "交通費/外食")).toEqual({
+      largeCategoryId: "L2",
+      middleCategoryId: "M4",
+    });
+  });
+
+  test("エラー: スラッシュなし", () => {
+    expect(() => resolveCategoryIds(meta, "食費")).toThrow();
+  });
+
+  test("エラー: スラッシュが2つ以上", () => {
+    expect(() => resolveCategoryIds(meta, "食費/外食/ランチ")).toThrow();
+  });
+
+  test("エラー: 未知の大項目", () => {
+    expect(() => resolveCategoryIds(meta, "娯楽費/映画")).toThrow();
+  });
+
+  test("エラー: 未知の中項目", () => {
+    expect(() => resolveCategoryIds(meta, "食費/映画")).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #8

## Summary

`bun:test` を使い以下の純関数にユニットテストを追加（計 16 テスト）。

| ファイル | 関数 | テスト数 |
|---|---|---|
| `src/scraper/transactions.test.ts` | `monthCursor`, `filterByDate` | 6 |
| `src/scraper/update.test.ts` | `resolveCategoryIds` | 6 |
| `src/commands/list.test.ts` | `toCsvRow` | 4 |

あわせて実施した変更：
- `monthCursor` / `filterByDate` を `export` に変更
- CSV 行生成を `toCsvRow` 関数として切り出して `export`

## Test plan

- [x] `bun test` → 16 pass / 0 fail