### PR TITLE
fix: send /cf/update as PUT instead of POST

### DIFF
--- a/src/scraper/update.test.ts
+++ b/src/scraper/update.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { resolveCategoryIds } from "./update.ts";
+import type { Page } from "playwright";
+import { resolveCategoryIds, updateTransaction } from "./update.ts";
 import type { CategoryMeta } from "../types.ts";
 
 const meta: CategoryMeta = {
@@ -45,5 +46,171 @@ describe("resolveCategoryIds", () => {
 
   test("エラー: 未知の中項目", () => {
     expect(() => resolveCategoryIds(meta, "食費/映画")).toThrow();
+  });
+});
+
+// updateTransaction は page.evaluate に渡すコールバックの中で fetch する。
+// テストでは evaluate をその場で実行する fake page を渡し、fetch / document を差し替えて
+// 実際に飛ぶリクエスト (method / URL / body / headers) を検査する
+type CapturedRequest = { url: string; init: RequestInit };
+
+function fakePage(): { page: Page; requests: CapturedRequest[] } {
+  const requests: CapturedRequest[] = [];
+  const page = {
+    evaluate: async <A, R>(fn: (arg: A) => R | Promise<R>, arg: A): Promise<R> => fn(arg),
+  } as unknown as Page;
+  return { page, requests };
+}
+
+function stubBrowserGlobals(
+  requests: CapturedRequest[],
+  response: { ok: boolean; status: number; body: string },
+  csrfToken: string | null = "csrf-token-value",
+): () => void {
+  const originalFetch = globalThis.fetch;
+  const originalDocument = (globalThis as { document?: unknown }).document;
+
+  (globalThis as { document?: unknown }).document = {
+    querySelector: (selector: string) =>
+      selector === 'meta[name="csrf-token"]' && csrfToken !== null ? { content: csrfToken } : null,
+  };
+
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    requests.push({ url, init });
+    return {
+      ok: response.ok,
+      status: response.status,
+      text: async () => response.body,
+    };
+  }) as unknown as typeof fetch;
+
+  return () => {
+    globalThis.fetch = originalFetch;
+    (globalThis as { document?: unknown }).document = originalDocument;
+  };
+}
+
+describe("updateTransaction", () => {
+  // ME の /cf/update は PUT のみ受け付ける。POST だと routing に無く 404 になる (#43)
+  test("PUT で /cf/update に送る", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, { ok: true, status: 200, body: "// js response" });
+
+    try {
+      await updateTransaction(page, "tx_1", { largeCategoryId: "11", middleCategoryId: "41" });
+    } finally {
+      restore();
+    }
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("/cf/update");
+    expect(requests[0]?.init.method).toBe("PUT");
+  });
+
+  test("body に txId / table_name / カテゴリ ID を載せる", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, { ok: true, status: 200, body: "// js response" });
+
+    try {
+      await updateTransaction(page, "tx_1", {
+        memo: "メモ",
+        largeCategoryId: "11",
+        middleCategoryId: "41",
+      });
+    } finally {
+      restore();
+    }
+
+    const body = new URLSearchParams(String(requests[0]?.init.body));
+    expect(body.get("user_asset_act[id]")).toBe("tx_1");
+    expect(body.get("user_asset_act[table_name]")).toBe("user_asset_act");
+    expect(body.get("user_asset_act[memo]")).toBe("メモ");
+    expect(body.get("user_asset_act[large_category_id]")).toBe("11");
+    expect(body.get("user_asset_act[middle_category_id]")).toBe("41");
+  });
+
+  test("指定していないフィールドは body に載せない", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, { ok: true, status: 200, body: "// js response" });
+
+    try {
+      await updateTransaction(page, "tx_1", { memo: "メモだけ" });
+    } finally {
+      restore();
+    }
+
+    const body = new URLSearchParams(String(requests[0]?.init.body));
+    expect(body.has("user_asset_act[large_category_id]")).toBe(false);
+    expect(body.has("user_asset_act[middle_category_id]")).toBe(false);
+  });
+
+  test("CSRF token をヘッダに載せる", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, { ok: true, status: 200, body: "// js response" });
+
+    try {
+      await updateTransaction(page, "tx_1", { memo: "m" });
+    } finally {
+      restore();
+    }
+
+    const headers = requests[0]?.init.headers as Record<string, string>;
+    expect(headers["X-CSRF-Token"]).toBe("csrf-token-value");
+  });
+
+  // 成功応答は text/javascript なので JSON にならない。これをエラー扱いしない
+  test("text/javascript の正常応答は成功として扱う", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, {
+      ok: true,
+      status: 200,
+      body: "  // /cf用\n var prevLargeCategorySelectedVal = (function() {",
+    });
+
+    try {
+      await expect(updateTransaction(page, "tx_1", { memo: "m" })).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("HTTP エラーは throw する", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, { ok: false, status: 500, body: "oops" });
+
+    try {
+      await expect(updateTransaction(page, "tx_1", { memo: "m" })).rejects.toThrow(/HTTP 500/);
+    } finally {
+      restore();
+    }
+  });
+
+  // 404 は JSON で返るので、そのメッセージを拾って報告する
+  test("JSON で返るエラーはメッセージを拾う", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, {
+      ok: false,
+      status: 404,
+      body: '{"status":404,"error":"Not Found"}',
+    });
+
+    try {
+      await expect(updateTransaction(page, "tx_1", { memo: "m" })).rejects.toThrow(
+        /update rejected: Not Found/,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("csrf-token が無ければ throw する", async () => {
+    const { page, requests } = fakePage();
+    const restore = stubBrowserGlobals(requests, { ok: true, status: 200, body: "" }, null);
+
+    try {
+      await expect(updateTransaction(page, "tx_1", { memo: "m" })).rejects.toThrow(/csrf-token/);
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/scraper/update.ts
+++ b/src/scraper/update.ts
@@ -60,8 +60,10 @@ export async function updateTransaction(
       if (payload.middleCategoryId)
         form.set("user_asset_act[middle_category_id]", payload.middleCategoryId);
 
+      // ME の UI は PUT で送る。DOM 上の form は method="post" だが Rails の
+      // method override で PUT になっており、POST だと routing に無く 404 が返る
       const res = await fetch("/cf/update", {
-        method: "POST",
+        method: "PUT",
         headers: {
           "X-CSRF-Token": token,
           "Content-Type": "application/x-www-form-urlencoded",
@@ -72,12 +74,15 @@ export async function updateTransaction(
         credentials: "same-origin",
       });
       const text = await res.text();
+      // 成功時の応答は text/javascript (Rails の format.js) なので JSON にはならない。
+      // 成否は res.ok で判定し、この JSON パースは 404 のように JSON で返るエラーの
+      // メッセージを拾うためだけに使う
       let bodyError: string | null = null;
       try {
         const json = JSON.parse(text) as Record<string, unknown>;
         if (typeof json["error"] === "string" && json["error"]) bodyError = json["error"];
       } catch {
-        // non-JSON body — ignore
+        // text/javascript の正常応答。エラー判定には使わない
       }
       return { ok: res.ok, status: res.status, bodyError, bodySnippet: text.slice(0, 300) };
     },


### PR DESCRIPTION
## 概要

`mfme update` の書き込みが `POST /cf/update` で HTTP 404 になり、単一 / バッチとも一切通らなかった (#43)。
**ME 側は `PUT` のみ受け付けている**ため、method を `PUT` に修正する。

Closes #43

## 原因

実 UI でカテゴリを変更し、Playwright の request interception で実リクエストを捕捉した:

```
REQ PUT https://moneyforward.com/cf/update
    headers: {"accept":"text/javascript","content-type":"application/x-www-form-urlencoded; charset=UTF-8","x-requested-with":"XMLHttpRequest"}
    body: user_asset_act[id]=<tx_id>&user_asset_act[large_category_id]=11&user_asset_act[middle_category_id]=41&...
RES 200
```

URL もフィールド名も CLI の送信内容と同一で、**違うのは HTTP method だけ**だった。
DOM 上の `form` は `method="post"` だが、実際の送信は Rails の method override で `PUT` になる。

CLI と同じ最小 payload で method / Accept を変えた比較:

| method | Accept | status | Content-Type |
| --- | --- | --- | --- |
| `PUT` | 現行 CLI と同じ | **200** | `text/javascript` |
| `PUT` | UI と同じ (`text/javascript`) | **200** | `text/javascript` |
| `POST` | 現行 CLI | **404** | `application/json` |

payload の追加 (`sub_account_id_hash` / `is_income` / `is_target`) も Accept の変更も不要だった。

## 変更

1. `src/scraper/update.ts` の `fetch` を `PUT` に変更
2. 成功応答が `text/javascript` (Rails の `format.js`) であることをコメントで明示。
   成否判定は `res.ok` で行い、JSON パースは 404 のように JSON で返るエラーの
   メッセージを拾うためだけに使う (レビューでの合意方針)
3. `updateTransaction` のテストを追加 (下記)

## テスト

`bun test`: **47 pass / 0 fail** (新規 8 件 / 既存 39 件)。

`updateTransaction` は `page.evaluate` の中で `fetch` するため、`evaluate` をその場で実行する
fake page に差し替え、`fetch` / `document` を stub して**実際に飛ぶリクエストを検査する**形にした。

| テスト | 検証内容 |
| --- | --- |
| PUT で /cf/update に送る | **method が `PUT`** であること (本 issue の再発防止) |
| body に txId / table_name / カテゴリ ID を載せる | 各フィールドの値 |
| 指定していないフィールドは body に載せない | `memo` のみ指定時にカテゴリ ID が乗らない |
| CSRF token をヘッダに載せる | `X-CSRF-Token` |
| text/javascript の正常応答は成功として扱う | JS 応答を JSON パース失敗でエラー扱いしない |
| HTTP エラーは throw する | 500 で `HTTP 500` を含む例外 |
| JSON で返るエラーはメッセージを拾う | 404 で `update rejected: Not Found` |
| csrf-token が無ければ throw する | token 不在時 |

**テスト自体が機能することを確認済み**: `method` を `POST` に戻すと
「PUT で /cf/update に送る」が落ちる (1 fail) ことを実測した。

## 動作確認 (実データ)

修正後に `update --stdin` で 3 件を実行:

```
$ mfme update --stdin < sample.ndjson
{"ok":true,"txId":"1883329387533828352"}
{"ok":true,"txId":"1883329387533762816"}
{"ok":true,"txId":"1883329387533697280"}
EXIT=0
```

修正前は同じ入力が 3 件とも `{"ok":false,...,"error":"update rejected: Not Found"}` / exit 4 だった。

- `bun test` 47 pass / `typecheck` / `lint` / `format:check` すべて green
- 入力は「対象取引に現在ついているカテゴリを書き戻す」冪等な内容。実行後に再取得して
  取得範囲 16 件の category / memo に差分が無いことを確認済み
- **注意**: 冪等入力のため「リクエストが受理される (200)」ことは確認できたが、
  「値の変更が永続化される」ことまでは本検証では確認していない。実際に値を変える
  検証が必要なら別途指示ください

sid: XAWZ4H
