### PR TITLE
fix: close browser and map exit code when launch/newPage throws

### DIFF
--- a/src/commands/browser-lifecycle.test.ts
+++ b/src/commands/browser-lifecycle.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppError } from "../errors.ts";
+import { EXIT } from "../types.ts";
+
+// launch() を差し替えて「newPage() が throw する」「launch() 自体が throw する」状況を作り、
+// handle.close() が必ず呼ばれることと exit code を検査する。
+// 実ブラウザは起動しない (CI は playwright install を実行しない)
+let closeCalls = 0;
+let launchError: Error | null = null;
+let newPageError: Error | null = null;
+
+mock.module("../browser.ts", () => ({
+  launch: async () => {
+    if (launchError) throw launchError;
+    return {
+      browser: {},
+      context: {
+        newPage: async () => {
+          if (newPageError) throw newPageError;
+          return {};
+        },
+        storageState: async () => ({}),
+      },
+      close: async () => {
+        closeCalls++;
+      },
+    };
+  },
+}));
+
+const { runList } = await import("./list.ts");
+const { runSyncMeta } = await import("./sync-meta.ts");
+const { runLogin } = await import("./login.ts");
+const { runUpdate } = await import("./update.ts");
+
+const commands: Array<{ name: string; run: () => Promise<number> }> = [
+  { name: "runList", run: () => runList({ format: "json" }) },
+  { name: "runSyncMeta", run: () => runSyncMeta() },
+  { name: "runLogin", run: () => runLogin() },
+  { name: "runUpdate", run: () => runUpdate({ txId: "tx_1", memo: "m", dryRun: false }) },
+];
+
+beforeEach(() => {
+  closeCalls = 0;
+  launchError = null;
+  newPageError = null;
+});
+
+describe("newPage() が throw したとき", () => {
+  for (const { name, run } of commands) {
+    test(`${name}: handle.close() を必ず呼ぶ`, async () => {
+      newPageError = new Error("newPage failed");
+
+      await run();
+
+      expect(closeCalls).toBe(1);
+    });
+
+    test(`${name}: 例外を投げずに exit code を返す`, async () => {
+      newPageError = new Error("newPage failed");
+
+      await expect(run()).resolves.toBe(EXIT.UNKNOWN);
+    });
+  }
+});
+
+describe("launch() 自体が throw したとき", () => {
+  for (const { name, run } of commands) {
+    test(`${name}: AppError の exitCode をそのまま返す`, async () => {
+      launchError = new AppError("session not found", EXIT.AUTH_FAILED);
+
+      await expect(run()).resolves.toBe(EXIT.AUTH_FAILED);
+      expect(closeCalls).toBe(0);
+    });
+  }
+});

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -18,26 +18,27 @@ export function toCsvRow(tx: import("../types.ts").Transaction): string {
 }
 
 export async function runList(args: ListArgs): Promise<number> {
-  const handle = await launch({ requireSession: true });
-  const page = await handle.context.newPage();
-
   try {
-    const txs = await fetchTransactions(page, { since: args.since, until: args.until });
-    if (args.format === "ndjson") {
-      for (const tx of txs) process.stdout.write(JSON.stringify(tx) + "\n");
-    } else if (args.format === "csv") {
-      process.stdout.write("id,date,amount,account,category,memo,title\n");
-      for (const tx of txs) {
-        process.stdout.write(toCsvRow(tx) + "\n");
+    const handle = await launch({ requireSession: true });
+    try {
+      const page = await handle.context.newPage();
+      const txs = await fetchTransactions(page, { since: args.since, until: args.until });
+      if (args.format === "ndjson") {
+        for (const tx of txs) process.stdout.write(JSON.stringify(tx) + "\n");
+      } else if (args.format === "csv") {
+        process.stdout.write("id,date,amount,account,category,memo,title\n");
+        for (const tx of txs) {
+          process.stdout.write(toCsvRow(tx) + "\n");
+        }
+      } else {
+        process.stdout.write(JSON.stringify(txs, null, 2) + "\n");
       }
-    } else {
-      process.stdout.write(JSON.stringify(txs, null, 2) + "\n");
+      return EXIT.OK;
+    } finally {
+      await handle.close();
     }
-    return EXIT.OK;
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));
     return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
-  } finally {
-    await handle.close();
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,33 +1,41 @@
 import { launch } from "../browser.ts";
+import { AppError } from "../errors.ts";
 import { saveSession } from "../session.ts";
 import { HOST_ME, URL_SIGN_IN } from "../scraper/urls.ts";
 import { log } from "../log.ts";
 import { EXIT } from "../types.ts";
 
 export async function runLogin(): Promise<number> {
-  const handle = await launch({ headed: true, requireSession: false });
-  const page = await handle.context.newPage();
-
-  log.info("ブラウザでログインしてください (MFA 含む)。ME 側に戻ってきたら自動で保存します。");
-  await page.goto(URL_SIGN_IN);
-
   try {
-    await page.waitForURL(
-      (u) => {
-        const url = new URL(u.toString());
-        return url.host === HOST_ME && !url.pathname.startsWith("/sign_in");
-      },
-      { timeout: 10 * 60_000 },
-    );
-  } catch {
-    log.error("ログイン待機がタイムアウトしました");
-    await handle.close();
-    return EXIT.AUTH_FAILED;
-  }
+    const handle = await launch({ headed: true, requireSession: false });
+    try {
+      const page = await handle.context.newPage();
 
-  const storageState = await handle.context.storageState();
-  await saveSession(storageState);
-  log.info(`セッションを保存しました (final URL: ${page.url()})`);
-  await handle.close();
-  return EXIT.OK;
+      log.info("ブラウザでログインしてください (MFA 含む)。ME 側に戻ってきたら自動で保存します。");
+      await page.goto(URL_SIGN_IN);
+
+      try {
+        await page.waitForURL(
+          (u) => {
+            const url = new URL(u.toString());
+            return url.host === HOST_ME && !url.pathname.startsWith("/sign_in");
+          },
+          { timeout: 10 * 60_000 },
+        );
+      } catch {
+        log.error("ログイン待機がタイムアウトしました");
+        return EXIT.AUTH_FAILED;
+      }
+
+      const storageState = await handle.context.storageState();
+      await saveSession(storageState);
+      log.info(`セッションを保存しました (final URL: ${page.url()})`);
+      return EXIT.OK;
+    } finally {
+      await handle.close();
+    }
+  } catch (e) {
+    log.error(e instanceof Error ? e.message : String(e));
+    return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
+  }
 }

--- a/src/commands/sync-meta.ts
+++ b/src/commands/sync-meta.ts
@@ -8,22 +8,24 @@ import { log } from "../log.ts";
 import { EXIT } from "../types.ts";
 
 export async function runSyncMeta(): Promise<number> {
-  const handle = await launch({ requireSession: true });
-  const page = await handle.context.newPage();
   try {
-    const meta = await fetchCategoryMeta(page);
+    const handle = await launch({ requireSession: true });
+    try {
+      const page = await handle.context.newPage();
+      const meta = await fetchCategoryMeta(page);
 
-    await mkdir(dirname(META_FILE), { recursive: true, mode: 0o700 });
-    await writeFile(META_FILE, JSON.stringify(meta, null, 2), { mode: 0o600 });
+      await mkdir(dirname(META_FILE), { recursive: true, mode: 0o700 });
+      await writeFile(META_FILE, JSON.stringify(meta, null, 2), { mode: 0o600 });
 
-    log.info(
-      `saved ${meta.large.length} large / ${meta.middle.length} middle categories to ${META_FILE}`,
-    );
-    return EXIT.OK;
+      log.info(
+        `saved ${meta.large.length} large / ${meta.middle.length} middle categories to ${META_FILE}`,
+      );
+      return EXIT.OK;
+    } finally {
+      await handle.close();
+    }
   } catch (e) {
     log.error(e instanceof Error ? e.message : String(e));
     return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
-  } finally {
-    await handle.close();
   }
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -71,8 +71,8 @@ export async function runUpdate(args: UpdateArgs): Promise<number> {
     }
 
     const handle = await launch({ requireSession: true });
-    const page = await handle.context.newPage();
     try {
+      const page = await handle.context.newPage();
       await page.goto(URL_CF, { waitUntil: "domcontentloaded" });
       await assertAuthenticated(page);
       await updateTransaction(page, args.txId, payload);


### PR DESCRIPTION
## 概要

`launch()` の後・`try` の前で `await` している箇所は、そこで throw すると `finally` に入らず
`handle.close()` を通らなかった。4 コマンドを `runUpdateBatch` と同じ
「外側 try/catch + 内側 try/finally」の形に揃える。

Closes #42

Base は #47 (`fix/session-missing-auth-failed`)。#47 が先に merge される前提のチェーン。

## 直した 2 種類の問題

### 1. `newPage()` が try の外 (元の指摘)

`list.ts` / `sync-meta.ts` / `login.ts` / `update.ts` (`runUpdate`) の 4 箇所。
`newPage()` が throw すると `handle.close()` に到達しない。

`login.ts` は **try/finally 自体が無く**、`newPage` / `goto` / `storageState` / `saveSession` の
いずれで throw しても close しなかった (close は正常系と timeout 時のみ)。

### 2. `launch()` の例外を捕捉していない (調査中に判明)

`list` / `sync-meta` は `launch()` を `try` の外で呼んでおり、例外がそのまま外に出ていた。
未ログインで実行すると次のようになる。

```
$ mfme list                       # 修正前
AppError: session not found. run `mfme login` first.
 exitCode: 1,
      at launch (src/browser.ts:30:11)
      at async runList (src/commands/list.ts:21:24)
      ... (スタックトレース)
EXIT=1     # bun の未捕捉例外の既定値。AppError.exitCode が使われた結果ではない
```

```
$ mfme list                       # 修正後
[error] session not found. run `mfme login` first.
EXIT=1     # AppError.exitCode のマッピング結果
```

`login.ts` も同様に外側 catch を追加した (元は例外が素通りしていた)。

## 変更後の形

```ts
try {
  const handle = await launch({ requireSession: true });
  try {
    const page = await handle.context.newPage();
    ...
  } finally {
    await handle.close();
  }
} catch (e) {
  log.error(e instanceof Error ? e.message : String(e));
  return e instanceof AppError ? e.exitCode : EXIT.UNKNOWN;
}
```

## テスト

`bun test`: **63 pass / 0 fail** (新規 12 件)。

`src/commands/browser-lifecycle.test.ts` を新規追加。`mock.module` で `../browser.ts` の
`launch()` を差し替え、実ブラウザを起動せずに 4 コマンドすべてを同じ観点で検査する。

| 観点 | 検証内容 | 件数 |
| --- | --- | --- |
| `newPage()` が throw | `handle.close()` がちょうど 1 回呼ばれる | 4 |
| `newPage()` が throw | 例外を投げずに exit code を返す | 4 |
| `launch()` が throw | `AppError` の `exitCode` をそのまま返し、`close()` は呼ばない | 4 |

**テスト自体が機能することを確認済み**: `list.ts` を旧形 (`newPage()` が try の外 /
`launch()` が catch の外) に戻すと **3 件落ちる**ことを実測した。

## 挙動の変化

| 対象 | 修正前 | 修正後 |
| --- | --- | --- |
| 未ログイン時の `list` / `sync-meta` | スタックトレース出力 | `[error] ...` 1 行 + exit 1 |
| `login` の実行時エラー | 素通り (スタックトレース) | `[error] ...` + exit code マッピング |
| `login` の timeout | `AUTH_FAILED(1)` | 変更なし |
| 各コマンドの正常系 | — | 変更なし |

issue には「挙動 (exit code / 出力) は変えない」と書いていたが、**捕捉していなかった例外を
捕捉する変更である以上、エラー経路の出力は必ず変わる**。正常系と `login` timeout の
`AUTH_FAILED(1)` は維持している。

## 動作確認

```
$ XDG_CONFIG_HOME=<empty> mfme list
[error] session not found. run `mfme login` first.     # stderr 1 行のみ
EXIT=1

$ XDG_CONFIG_HOME=<empty> mfme sync-meta
[error] session not found. run `mfme login` first.
EXIT=1
```

`bun test` 63 pass / `typecheck` / `lint` / `format:check` すべて green。

sid: XAWZ4H
