### PR TITLE
docs: document memo append via jq pipe instead of adding --memo-append

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,22 @@ mfme list --since 2026-01-01 --format ndjson \
   | mfme update --stdin > result.ndjson
 ```
 
+### memo の追記
+
+`memo` は常に上書きなので、追記したい場合は `list` で取得した現在の値に足してから流す。
+`--stdin` は NDJSON を受けるだけなので、この組み立ては `jq` 側で完結する。
+
+```sh
+mfme list --since 2026-01-01 --format ndjson \
+  | jq -c '{txId: .id, memo: ((.memo // "") + " 追記テキスト")}' \
+  | mfme update --stdin
+```
+
+`memo` が未設定の取引は `list` の出力で `null` になるので `// ""` で空文字に落とす。
+先頭の余分なスペースが気になる場合は `| ltrimstr(" ")` を挟む。
+
+読んでから書くまでの間に ME 側で memo が変わっていると、その変更は上書きされる。
+
 ## 制約
 
 1. 連携口座取引は読み取り・メモ/カテゴリ編集のみ。金額/日付は不変。


### PR DESCRIPTION
## 概要

#44 の論点 3 (memo の上書き vs 追記) の結論を README に反映する。
**`--memo-append` は CLI に追加しない**方針で確定 (ユーザー承認済み)。

Refs #44

## 判断

`--stdin` は NDJSON を受けるだけなので、追記は入力側 (`jq`) で完結する。

```sh
mfme list --since 2026-01-01 --format ndjson \
  | jq -c '{txId: .id, memo: ((.memo // "") + " 追記テキスト")}' \
  | mfme update --stdin
```

CLI に `--memo-append` を持たせる場合、更新対象の**現在の memo を CLI 側で取得する必要**があり、
`list` と同じ取得処理を `update` にも抱えることになる。加えて区切り文字の仕様、
単一 `update` と `--stdin` での意味の一致、read-modify-write の競合と論点が増える一方、
得られるのは「`jq` を 1 つ書かなくてよい」だけ。

## 変更

README の想定ワークフローに「memo の追記」節を追加。

- 追記のパイプ例
- `list` の出力で `memo` が `null` になる取引は `// ""` で空文字に落とす点
- 先頭スペースが不要なら `ltrimstr(" ")` を挟む点
- 読んでから書くまでに ME 側で memo が変わっていると上書きされる点

## 動作確認

README に載せたコマンドを実データに対して dry-run で実行し、動くことを確認済み。

```
$ mfme list ... | jq -c '{txId: .id, memo: ((.memo // "") + " 追記テキスト")}' | mfme update --stdin --dry-run
{"dryRun":true,"txId":"1883329387533828352","payload":{"memo":" 追記テキスト"}}
{"dryRun":true,"txId":"1883329387533762816","payload":{"memo":" 追記テキスト"}}
EXIT=0

$ ... | jq -c '{txId: .id, memo: (((.memo // "") + " 追記テキスト") | ltrimstr(" "))}' | mfme update --stdin --dry-run
{"dryRun":true,"txId":"1883329387533828352","payload":{"memo":"追記テキスト"}}
EXIT=0
```

`format:check` green。ドキュメントのみの変更のためコード変更・テスト追加はなし。

sid: XAWZ4H